### PR TITLE
Update mongojs version number

### DIFF
--- a/day-1/package.json
+++ b/day-1/package.json
@@ -9,6 +9,6 @@
   "author": "Kendall Buchanan <kendall@teachbanzai.com> (https://github.com/kendagriff)",
   "license": "ISC",
   "dependencies": {
-    "mongojs": "2.3.0"
+    "mongojs": "2.4.0"
   }
 }


### PR DESCRIPTION
Node v6 breaks mongojs 2.3.0.

mongojs 2.4.0 is compatible with Node v6.
